### PR TITLE
Fix the use of reserve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eiche"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Ranjeeth Mahankali <ranjeethmahankali@gmail.com>"]
 description = "A library with tools for working with symbolic expressions."

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -396,7 +396,7 @@ impl Tree {
             return Err(Error::DimensionMismatch(self.dims, other.dims));
         }
         self.nodes
-            .reserve(self.nodes.len() + other.nodes.len() + usize::max(nroots, other_nroots));
+            .reserve(other.nodes.len() + usize::max(nroots, other_nroots));
         let offset = self.push_nodes(&other);
         if nroots == 1 {
             let root = offset - 1;
@@ -426,8 +426,7 @@ impl Tree {
         if nroots != 1 && nroots != anroots {
             return Err(Error::DimensionMismatch(self.dims, a.dims));
         }
-        self.nodes
-            .reserve(self.nodes.len() + a.nodes.len() + b.nodes.len() + 1);
+        self.nodes.reserve(a.nodes.len() + b.nodes.len() + 1);
         let a_offset = self.push_nodes(&a);
         let b_offset = self.push_nodes(&b);
         if nroots == 1 {


### PR DESCRIPTION
I recently learned that the `reserve` in Rust isn't the same as `reserve` in C++. I had used it incorrectly in a few places because of this misunderstanding. This fixes that.